### PR TITLE
Update how-devkit-install.md

### DIFF
--- a/docs/docs/how-devkit-install.md
+++ b/docs/docs/how-devkit-install.md
@@ -14,30 +14,32 @@ TODO:
 
 ## Warning: This is a giant mess right now!
 
-Due to sillyness, there is a jar checked into the repo, so you can skip down to using the Dev Kit. However, you do need Java 11 installed.
+Due to sillyness, there is a jar checked into the repo, so you can skip down to using the devkit. However, you do need Java 11 installed.
 
 ## Building Instructions
 
-Adama uses Java 11 and Maven, and has a simple build script. Running the python script:
+Before you build Adama, you must first install [Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) and [Apache Maven](https://maven.apache.org/download.cgi).
+
+With Java 11 and Maven installed, you can then run the Adama build script. The following Python script builds Adama:
 
 ```sh
 ./build.py jar
 ```
 
-will create ```demo/devkit.jar``` which is the jar.
+The build script will create ```demo/devkit.jar``` which is the jar.
 
-## Using Dev Kit
+## Using the Devkit
 
-### Running Demo
+### Running the Adama Demo
 
-A fast way to get familiar to look at the demo. Since the devkit is just an HTTP server, you can run the server within the demo directory.
+A fast way to familiarize yourself with Adama is to run the demo. Since the devkit is just an HTTP server, you can run the server within the demo directory using the following commands:
 
 ```sh
 cd demo
 jar -jar devkit.jar
 ```
 
-### About usernames and passwords
-The DevKit allows any username with the password 'pw'. This silly convention allows you to get going faster, and you use a multi-tab container to deal with multiple users.
+### About the Demo Username and Password
+To help familiarize yourself with the devkit, it allows any username with the password 'pw' to authenticate. These credentials allow you to easily get started, and you can use a multi-tab container to manage multiple users.
 
-As a future ideal, it would be nice to have multiple users within iframes. This requires finalizing some design issues around users.
+In the future, Adama will have multiple users managed within iframes, but this requires changes to design.


### PR DESCRIPTION
Grammar edits. Cleaned up some of the wording. Also, linked Java and Maven just to make it more convenient for users to quickly download and install the files.

As a side note, I see that the demo has a static username and password. Perhaps it might be necessary for security for them to change it if installed on production? Not sure if that is necessary for a demo, but it's something I thought of as I was reading it.