### PR TITLE
Adding 'change' event to rx:<event> list

### DIFF
--- a/core/src/main/java/org/adamalang/rxhtml/template/Base.java
+++ b/core/src/main/java/org/adamalang/rxhtml/template/Base.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.function.Function;
 
 public class Base {
-  private static final String[] EVENTS = new String[]{"click", "mouseenter", "mouseleave", "load", "success", "failure", "blur", "focus"};
+  private static final String[] EVENTS = new String[]{"click", "mouseenter", "mouseleave", "load", "success", "change", "failure", "blur", "focus"};
 
   private static String xmlnsOf(Environment env) {
     String xmlns = env.element.hasAttr("xmlns") ? env.element.attr("xmlns") : null;


### PR DESCRIPTION
- Added 'change' to the list of events that rx listens for
- This can be used to listen for the event that fires after a file is uploaded from an `<input type='file' />` element
- To use, you can add `rx:change="..."` as an attribute inside any rxhtml element that fires a 'change' event