### PR TITLE
Making `$key` available inside rx:iterate when 'rx:expand-view-state' is present

### DIFF
--- a/clientjs/rxhtml.js
+++ b/clientjs/rxhtml.js
@@ -886,7 +886,6 @@ var RxHTML = (function () {
         }
       }
     };
-    console.log(state)
     subscribe(state, name, sub);
   };
 

--- a/clientjs/rxhtml.js
+++ b/clientjs/rxhtml.js
@@ -850,6 +850,9 @@ var RxHTML = (function () {
         var item_delta = new_state.data.delta;
         new_state.data.delta = {};
         subscribe_state(new_state, unsub);
+        if (expandView) {
+          state.view.tree.update(path_to(new_state.view, {"$index": key}));
+        };
         return item_delta;
       },
       "-": function (key) {
@@ -883,6 +886,7 @@ var RxHTML = (function () {
         }
       }
     };
+    console.log(state)
     subscribe(state, name, sub);
   };
 

--- a/clientjs/rxhtml.js
+++ b/clientjs/rxhtml.js
@@ -851,7 +851,7 @@ var RxHTML = (function () {
         new_state.data.delta = {};
         subscribe_state(new_state, unsub);
         if (expandView) {
-          state.view.tree.update(path_to(new_state.view, {"$index": key}));
+          state.view.tree.update(path_to(new_state.view, {"$key": key}));
         };
         return item_delta;
       },


### PR DESCRIPTION
- Adding the 'key' from rx:iterate to the view state via `$key`
- This is only added when `rx:expand-view-state` is added to the element with `rx:iterate`