### PR TITLE
Added missing opening <body> tag

### DIFF
--- a/core/src/main/java/org/adamalang/rxhtml/CapacitorJSShell.java
+++ b/core/src/main/java/org/adamalang/rxhtml/CapacitorJSShell.java
@@ -84,7 +84,7 @@ public class CapacitorJSShell {
       sb.append("  <style>\n").append(internStyle).append("\n </style>\n");
     }
     sb.append(" </head>\n");
-    sb.append("</body>\n<script>\n");
+    sb.append("<body></body>\n<script>\n");
     sb.append("  RxHTML.mobileInit(\"").append(domainOverride).append("\");\n");
     sb.append("  RxHTML.init();\n");
     sb.append("  LinkCapacitor(RxHTML, \"").append(workerIdentity).append("\");\n");


### PR DESCRIPTION
It will show an error on vite build: Unable to parse html

    at async viteIndexHtmlMiddleware (/Users/dmontecillo/Private/FulloutSoftwareProjects/engineering/mobile/web-app-conv/node_modules/vite/dist/node/chunks/dep-6e2fe41e.js:57809:28) (x6)
9:25:26 PM [vite] Internal server error: Unable to parse HTML; Invalid end tag.
 at {"file":"/index.html","line":63640,"column":1}
63637|  })(RxHTML);
63638|    </script>
63639|   </head>
   |           ^
63640|  </body>
63641|  <script>
   at {"file":"/index.html","line":63640,"column":1}
      at handleParseError (/Users/dmontecillo/Private/FulloutSoftwareProjects/engineering/mobile/web-app-conv/node_modules/vite/dist/node/chunks/dep-6e2fe41e.js:36434:11)
      at traverseHtml (/Users/dmontecillo/Private/FulloutSoftwareProjects/engineering/mobile/web-app-conv/node_modules/vite/dist/node/chunks/dep-6e2fe41e.js:36390:9)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async devHtmlHook (/Users/dmontecillo/Private/FulloutSoftwareProjects/engineering/mobile/web-app-conv/node_modules/vite/dist/node/chunks/dep-6e2fe41e.js:57739:5)
      at async applyHtmlTransforms (/Users/dmontecillo/Private/FulloutSoftwareProjects/engineering/mobile/web-app-conv/node_modules/vite/dist/node/chunks/dep-6e2fe41e.js:36800:21)
      at async viteIndexHtmlMiddleware (/Users/dmontecillo/Private/FulloutSoftwareProjects/engineering/mobile/web-app-conv/node_modules/vite/dist/node/chunks/dep-6e2fe41e.js:57809:28) (x7)