### PR TITLE
Currency transforms

### DIFF
--- a/clientjs/rxhtml.js
+++ b/clientjs/rxhtml.js
@@ -3448,11 +3448,17 @@ var RxHTML = (function () {
   transforms['currency'] = function(x, fmt) {
     const num = parseFloat(x);
     if (isNaN(num)) return x;
-    return new Intl.NumberFormat([], {
-      style: 'currency',
-      currency: fmt,
-      useGrouping: true,
-    }).format(num)
+    try {
+      return new Intl.NumberFormat([], {
+        style: 'currency',
+        currency: fmt,
+        useGrouping: true,
+      }).format(num)
+    } catch (error) {
+      console.error("'currency' transform error: ", error);
+      return x;
+    }
+    
   }
   
 

--- a/clientjs/rxhtml.js
+++ b/clientjs/rxhtml.js
@@ -3448,11 +3448,11 @@ var RxHTML = (function () {
   transforms['currency'] = function(x, fmt) {
     const num = parseFloat(x);
     if (isNaN(num)) return x;
-    return num.toLocaleString([],{
+    return new Intl.NumberFormat([], {
       style: 'currency',
       currency: fmt,
       useGrouping: true,
-    });
+    }).format(num)
   }
   
 

--- a/clientjs/rxhtml.js
+++ b/clientjs/rxhtml.js
@@ -3444,6 +3444,16 @@ var RxHTML = (function () {
       return d;
     }
   }
+
+  transforms['currency'] = function(x, fmt) {
+    const num = parseFloat(x);
+    if (isNaN(num)) return x;
+    return num.toLocaleString([],{
+      style: 'currency',
+      currency: fmt,
+      useGrouping: true,
+    });
+  }
   
 
   self.RTR = function(name, transform) {


### PR DESCRIPTION
### transform="currency:XXX"

- Add this transform to automatically format the passed in number to the given currency format
- It can be extended to any currency format supported by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat)