### PR TITLE
[Mobile]: check url rather than deleted navigation var before redirect

### DIFF
--- a/clientjs/rxcapacitor.js
+++ b/clientjs/rxcapacitor.js
@@ -62,7 +62,7 @@ async function LinkCapacitor($, identityName) {
     if (!localStorage.getItem("mdo_host")) {
       $.registerManifest(`${url.origin}/~d/.product-manifest.json`, true);
     }
-    if (navigation.length > 1) {
+    if (url.parthname > 1) {
       window.rxhtml.goto(url.pathname, true);
     }
   });

--- a/clientjs/rxcapacitor.js
+++ b/clientjs/rxcapacitor.js
@@ -62,7 +62,7 @@ async function LinkCapacitor($, identityName) {
     if (!localStorage.getItem("mdo_host")) {
       $.registerManifest(`${url.origin}/~d/.product-manifest.json`, true);
     }
-    if (url.parthname > 1) {
+    if (url.pathname > 1) {
       window.rxhtml.goto(url.pathname, true);
     }
   });


### PR DESCRIPTION
Previous PR refactored `appUrlOpen` listener to use URL constructor but failed to update the check prior to navigating. 